### PR TITLE
fix: remove place of death label on family member page if empty

### DIFF
--- a/views/member/details.hbs
+++ b/views/member/details.hbs
@@ -63,7 +63,7 @@
               </div>
               {{/if}}
 
-              {{#if member.placeOfBirth}}
+              {{#if member.placeOfDeath}}
               <div class="col mt-3 mt-sm-0">
                 <small class="text-secondary text-opacity-75">Place of death</small>
                 <p class="m-0">{{member.placeOfDeath}}</p>


### PR DESCRIPTION
Closes #103 